### PR TITLE
Change <code> style to apply also outside of <p>, so code formatting will work in lists

### DIFF
--- a/static/pneumatic.scss
+++ b/static/pneumatic.scss
@@ -169,7 +169,7 @@ abbr, acronym, .abbr {
 	top: -0.7em;
 }
 
-p > code {
+code {
 	font-family: $code-font;
 	color: #6e6b5e;
 	background: #f5f5f5;


### PR DESCRIPTION
Before change, inline code in lists (rendered with markdown) Is not formatted because it's not inside <p> tag. Example:
"1. one two `code` one"
